### PR TITLE
Added a Maintainer field to the Debian packaging control file, to stop showing a warning every time someone installs a package

### DIFF
--- a/app/packaging/linux/deb/DEBIAN/control
+++ b/app/packaging/linux/deb/DEBIAN/control
@@ -1,5 +1,6 @@
 Package: {{packageName}}
 Version: {{applicationVersion}}
 Priority: optional
+Maintainer: Matt Hensman <m+github@matt.tf>
 Architecture: amd64
 Description: {{applicationName}}


### PR DESCRIPTION
Without a maintainer field, if the user has the fx_cast deb package installed, this is shown each time a package is installed: "dpkg: warning: parsing file '/var/lib/dpkg/status' near line 60312 package 'fx-cast-bridge': missing maintainer".