### PR TITLE
tab: support hidpi device

### DIFF
--- a/ext/src/senders/mirroring.ts
+++ b/ext/src/senders/mirroring.ts
@@ -81,13 +81,16 @@ async function onRequestSessionSuccess (newSession: cast.Session) {
             }
 
             // Set initial size
-            canvas.width = window.innerWidth;
-            canvas.height = window.innerHeight;
+            canvas.width = window.innerWidth * window.devicePixelRatio;
+            canvas.height = window.innerHeight * window.devicePixelRatio;
+            ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
 
             // Resize canvas whenever the window resizes
             window.addEventListener("resize", () => {
-                canvas.width = window.innerWidth;
-                canvas.height = window.innerHeight;
+                canvas.width = window.innerWidth * window.devicePixelRatio;
+                canvas.height = window.innerHeight * window.devicePixelRatio;
+                ctx.setTransform(1, 0, 0, 1, 0, 0);
+                ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
             });
 
             // TODO: Test performance


### PR DESCRIPTION
This commit make canvas in full device pixel size and set proper scale
on it, so that drawWindow draws all pixels instead of scaling down to
normal dpi.