### PR TITLE
Adds a FAQ for installing the bridge with Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ The bridge application is currently supported on Windows, macOS and Linux.
 
 ### Installing via package managers
 
-**Note**: These packages are maintained by third parties and support likely will not be provided for any issues specific to these packages.
+**Note**: These packages are maintained by third parties and any issues specfic to these packages should be directed to the respective package maintainers.
 
+-   **macOS (Homebrew cask)**
+    -   `fx-cast-bridge` — https://formulae.brew.sh/cask/fx-cast-bridge  
+        Install by running `brew install --cask fx-cast-bridge`.
 -   **Arch Linux (AUR)**
-    -   `fx_cast` — https://aur.archlinux.org/packages/fx_cast
     -   `fx_cast-bin` — https://aur.archlinux.org/packages/fx_cast-bin
 
 ### Daemon Configuration

--- a/docs/index.css
+++ b/docs/index.css
@@ -307,6 +307,9 @@ h3.download__bridge-header {
 .faq__content code {
     background-color: var(--grey-10-a10);
     border-radius: 3px;
+    display: inline-block;
+    margin: 1px 0;
+    padding: 0.25em 0.5em;
     white-space: nowrap;
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -197,18 +197,43 @@
                                 <details class="faq">
                                     <summary class="faq__summary">
                                         <h3>
-                                            Can I install the bridge through
-                                            a package manager?
+                                            Can I install the bridge through a
+                                            package manager?
                                         </h3>
                                     </summary>
                                     <div class="faq__content">
                                         <p>
+                                            The bridge is available for macOS
+                                            and Arch Linux via several third
+                                            party packages. The extension is not
+                                            bundled with these packages and must
+                                            still be installed separately.
+                                        </p>
+                                        <p class="disclaimer">
+                                            Any issues specific to these
+                                            packages should be directed to the
+                                            respective package maintainers.
+                                        </p>
+                                        <h4>macOS</h4>
+                                        <p>
                                             The bridge is available via
-                                            <a href="https://brew.sh">Homebrew</a>
+                                            <a href="https://brew.sh"
+                                                >Homebrew</a
+                                            >
                                             for macOS by running
-                                            <code>brew install --cask fx-cast-bridge</code>.
-                                            You will of course need to install
-                                            the extension separately.
+                                            <code
+                                                >brew install --cask
+                                                fx-cast-bridge</code
+                                            >.
+                                        </p>
+
+                                        <h4>Arch Linux (AUR)</h4>
+                                        <p>
+                                            <code>fx_cast-bin</code> —
+                                            <a
+                                                href="https://aur.archlinux.org/packages/fx_cast-bin"
+                                                >https://aur.archlinux.org/packages/fx_cast-bin</a
+                                            >
                                         </p>
                                     </div>
                                 </details>

--- a/docs/index.html
+++ b/docs/index.html
@@ -197,6 +197,26 @@
                                 <details class="faq">
                                     <summary class="faq__summary">
                                         <h3>
+                                            Can I install the bridge through
+                                            a package manager?
+                                        </h3>
+                                    </summary>
+                                    <div class="faq__content">
+                                        <p>
+                                            The bridge is available via
+                                            <a href="https://brew.sh">Homebrew</a>
+                                            for macOS by running
+                                            <code>brew install --cask fx-cast-bridge</code>.
+                                            You will of course need to install
+                                            the extension separately.
+                                        </p>
+                                    </div>
+                                </details>
+                            </li>
+                            <li class="faqs__list-item">
+                                <details class="faq">
+                                    <summary class="faq__summary">
+                                        <h3>
                                             Why aren't my devices being found?
                                         </h3>
                                     </summary>


### PR DESCRIPTION
fx-cast-bridge was added to Homebrew's Casks in https://github.com/Homebrew/homebrew-cask/pull/141788 so let's mention it on the FAQ.

It could be more prominent on the page but I didn't want to add a new section unnecessarily so the FAQ seemed OK.
